### PR TITLE
feat: route resubmit uploads by role

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -342,9 +342,14 @@ exports.resubmitProfile = async (req, res) => {
             if (newFile) {
                 const existingProfile = await prisma.coProfile.findUnique({ where: { user_id: userId }, select: { selfie_url: true } });
                 if (existingProfile?.selfie_url) {
-                    const oldFilePath = path.join(__dirname, '..', existingProfile.selfie_url.replace(/^\//, ''));
-                    try { await fs.unlink(oldFilePath); console.log(`File lama CO ${oldFilePath} berhasil dihapus.`); }
-                    catch (e) { console.error("Gagal hapus file lama CO:", e.message); }
+                    const relativePath = existingProfile.selfie_url.replace(/^[/\\]/, '');
+                    const oldFilePath = path.join(__dirname, '..', 'public', relativePath);
+                    try {
+                        await fs.unlink(oldFilePath);
+                        console.log(`File lama CO ${oldFilePath} berhasil dihapus.`);
+                    } catch (e) {
+                        console.error("Gagal hapus file lama CO:", e.message);
+                    }
                 }
                 profileDataForUpdate.selfie_url = `/uploads/selfies/${newFile.filename}`;
             }
@@ -372,9 +377,14 @@ exports.resubmitProfile = async (req, res) => {
             if (newFile) {
                 const existingProfile = await prisma.mitraProfile.findUnique({ where: { user_id: userId }, select: { store_images: true } });
                 if (existingProfile?.store_images) {
-                    const oldFilePath = path.join(__dirname, '..', existingProfile.store_images.replace(/^\//, ''));
-                    try { await fs.unlink(oldFilePath); console.log(`File lama Mitra ${oldFilePath} berhasil dihapus.`); }
-                    catch (e) { console.error("Gagal hapus file lama Mitra:", e.message); }
+                    const relativePath = existingProfile.store_images.replace(/^[/\\]/, '');
+                    const oldFilePath = path.join(__dirname, '..', 'public', relativePath);
+                    try {
+                        await fs.unlink(oldFilePath);
+                        console.log(`File lama Mitra ${oldFilePath} berhasil dihapus.`);
+                    } catch (e) {
+                        console.error("Gagal hapus file lama Mitra:", e.message);
+                    }
                 }
                 profileDataForUpdate.store_images = `/uploads/stores/${newFile.filename}`;
             }

--- a/middleware/upload.js
+++ b/middleware/upload.js
@@ -6,25 +6,43 @@ const fs = require('fs');
 // Konfigurasi storage untuk penyimpanan lokal
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
-     let uploadPath = 'public/uploads/others';
-    // Pastikan direktori ada, jika tidak, buat direktorinya
+    let uploadPath = 'public/uploads/others';
     // Cek URL request untuk menentukan folder tujuan
-    if (req.originalUrl.includes('/register/captain') || req.originalUrl.includes('/resubmit')) {
-      // Jika dari registrasi/resubmit Captain (CO), simpan di 'selfies'
+    if (
+      req.originalUrl.includes('/register/captain') ||
+      (req.originalUrl.includes('/resubmit') && req.user?.role === 'co')
+    ) {
+      // registrasi/resubmit Captain (CO)
       uploadPath = 'public/uploads/selfies';
-    } else if (req.originalUrl.includes('/register/mitra')) {
-      // Jika dari registrasi Mitra, simpan di 'stores'
+    } else if (
+      req.originalUrl.includes('/register/mitra') ||
+      (req.originalUrl.includes('/resubmit') && req.user?.role === 'mitra')
+    ) {
+      // registrasi/resubmit Mitra
       uploadPath = 'public/uploads/stores';
     }
-    
+
     fs.mkdirSync(uploadPath, { recursive: true });
     cb(null, uploadPath);
   },
   filename: (req, file, cb) => {
     // Buat nama file yang unik untuk menghindari konflik
-    // Format: selfie-timestamp.extension
     const uniqueSuffix = Date.now() + path.extname(file.originalname);
-    cb(null, `selfie-${uniqueSuffix}`);
+    let prefix = 'file-';
+
+    if (
+      req.originalUrl.includes('/register/captain') ||
+      (req.originalUrl.includes('/resubmit') && req.user?.role === 'co')
+    ) {
+      prefix = 'selfie-';
+    } else if (
+      req.originalUrl.includes('/register/mitra') ||
+      (req.originalUrl.includes('/resubmit') && req.user?.role === 'mitra')
+    ) {
+      prefix = 'store-';
+    }
+
+    cb(null, `${prefix}${uniqueSuffix}`);
   }
 });
 


### PR DESCRIPTION
## Summary
- route resubmit uploads to role-specific directories
- tag files with destination-specific prefixes
- fix removal of old uploads to account for public directory

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b0ed0786c832092257147323eabbc